### PR TITLE
Fix transaction file

### DIFF
--- a/le_server.py
+++ b/le_server.py
@@ -281,21 +281,12 @@ class Server():
             subprocess32.check_call(cmd, stdout=log, stderr=log, shell=False)
         except subprocess32.CalledProcessError as err:
             print 'Execution error: {}'.format(err.returncode)
-            self.remove_lock_file()
             return 1
 
         print("--- %s seconds ---" % (time.time() - start_time))
         log.close()
         os.unlink(log.name)
         return 0
-
-    def remove_lock_file(self):
-        # Deletes Lockfile if process was interrupted.
-        # https://github.com/lukas2511/dehydrated/issues/31
-        try:
-            os.remove('lock')
-        except:
-            pass
 
     def start(self):
         if (int(self.port) == 443):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ grequests
 six
 subprocess32
 uwsgi
+urllib3[secure]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 M2Crypto
 flask
 pem
-requests
+requests[security]
 grequests
 six
 subprocess32


### PR DESCRIPTION
The transaction file now lives in a directory created with mktemp, removed on completion.  This is more secure, prevents clutter, and avoids depending on the current directory being writable.

Also sneaks in a `requirements.txt` addition.

@chriddyp Please review.