### PR TITLE
Fix aborting failed domain add

### DIFF
--- a/gcloudhook/hook.sh
+++ b/gcloudhook/hook.sh
@@ -83,7 +83,7 @@ function deploy_challenge() {
         changeID=$($GCLOUD dns record-sets transaction execute "$transaction_file_arg" --zone "$ZONE_NAME"  --format='value(id)')
 
         if [[ -z "$changeID" ]]; then
-             $GCLOUD dns record-sets transaction abort $transaction_file_arg --zone
+             $GCLOUD dns record-sets transaction abort $transaction_file_arg --zone "$ZONE_NAME"
              return 1
         fi
     }


### PR DESCRIPTION
This fixes concurrency since it will allow requests that fail due to races to be retried.

Tested on stage with 5 simultaneous requests (the maximum allowed by our current server configuration).

@chriddyp Please review.