### PR TITLE
Ubuntu upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Python 2.7 environment
 Let's Encrypt shell client dehydrated
 
 ```bash
-curl -sL https://github.com/lukas2511/dehydrated/archive/v0.3.1.tar.gz | tar xz
+curl -sL https://github.com/lukas2511/dehydrated/archive/v0.4.0.tar.gz | tar xz
 ```
 
 Assuming your domain is `your-domain.com` that is under `your-zone` zone in your Google Cloud DNS records,

--- a/gcloudhook/hook.sh
+++ b/gcloudhook/hook.sh
@@ -247,4 +247,8 @@ function unchanged_cert() {
     echo "Certificate for domain $DOMAIN is still valid - no action taken"
 }
 
+function exit_hook() {
+    exit 0
+}
+
 HANDLER="$1"; shift; "$HANDLER" "$@"


### PR DESCRIPTION
part of plotly/streambed#12532

I needed to upgrade dehydrated due to the following error : 
`error:0D07207B:asn1 encoding routines:ASN1_get_object:header too long`

I added the exit_hook which has been added to version 0.4.0 see changelog : 
https://github.com/lukas2511/dehydrated/releases/tag/v0.4.0

@scjody can you review this pr?